### PR TITLE
feat(exercise-4 and exercise-2): Manual RAG with Prompt Templates and Fixes to exercise-2

### DIFF
--- a/src/main/resources/simv/glosario.txt
+++ b/src/main/resources/simv/glosario.txt
@@ -1,0 +1,158 @@
+Definiciones fundamentales del mercado de valores. Para la aplicación de esta
+ley y sus reglamentos, se entenderá por:
+
+1) Anotaciones en cuenta. Son asientos registrales de naturaleza contable que constituyen en
+   sí mismos la representación inmaterial de los valores y otorgan la propiedad de los mismos al
+   titular que figure inscrito en un depósito centralizado de valores.
+2) Asesoría de inversión. Es la actividad remunerada que tiene por objeto dar información,
+   consejo, opinión, análisis, recomendación y, en general, proporcionar asistencia o incidir
+   -4-
+   sobre modalidades de inversión, mantenimiento o cambio de inversiones u oportunidades
+   para la realización de operaciones de inversión en el mercado de valores.
+3) Calificación de riesgo. Es la opinión técnica y especializada que emiten las sociedades
+   calificadoras de riesgo.
+4) Conflicto de interés. Es cualquier situación, a consecuencia de la cual una persona física o
+   jurídica, pueda obtener ventajas o beneficios, para sí o para terceros, y que afecte su
+   independencia al momento de la toma de decisiones.
+5) Corredor de valores. Es una persona física dependiente de un intermediario de valores
+   que en su representación realiza actividades con valores de oferta pública.
+6) Deber de mejor ejecución. Es la adopción de las medidas razonables para obtener el mejor
+   resultado posible para las operaciones y transacciones en el mercado de valores, teniendo
+   en cuenta el tipo de inversionista, el precio, los costos, la rapidez y probabilidad en la
+   ejecución y liquidación, el volumen, la naturaleza de la operación y cualquier otro elemento
+   relevante para la ejecución de la orden o instrucción del cliente.
+7) Ejecutivos principales. Son las personas físicas que desempeñan cargos ejecutivos de
+   dirección y operación del negocio de una sociedad, así como las demás personas que
+   prestan funciones de alta administración, dirección y control en la misma.
+8) Emisión. Es el conjunto de valores negociables que proceden de un mismo emisor y que se
+   pueden considerar homogéneos entre sí, atribuyéndole a sus tenedores un contenido similar
+   de determinados derechos y obligaciones, que forman parte de una misma operación
+   financiera y que responden a una unidad de propósito.
+9) Emisor. Es la persona jurídica que se inscribe en el Registro del Mercado de Valores para
+   realizar una oferta pública de valores, previa autorización de la Superintendencia.
+10) Emisor diferenciado. Son el Gobierno Central de la República Dominicana, el Banco
+    Central de la República Dominicana, los organismos multilaterales de los cuales la
+    República Dominicana sea miembro, los gobiernos centrales y bancos centrales
+    extranjeros, cuyos valores se negocien en la República Dominicana bajo condiciones de
+    reciprocidad.
+11) Entidad de Contrapartida Central: Es una entidad que se interpone entre las contrapartes
+    de los contratos negociados en uno o más mercados financieros, convirtiéndose en el
+    comprador para cada vendedor y en el vendedor para cada comprador, garantizando así la
+    ejecución de los contratos abiertos.
+12) Fideicomiso de oferta pública. Es el fideicomiso de oferta pública de valores y productos,
+    establecido en la Ley No.189-11, para el Desarrollo del Mercado Hipotecario y el
+    Fideicomiso en la República Dominicana, de fecha 16 de julio del 2011.
+    -5-
+13) Fondo de inversión. Es un esquema de inversión colectiva mediante un patrimonio
+    autónomo que se constituye con el aporte de sumas de dinero de personas físicas o jurídicas,
+    denominadas aportantes, para su inversión, por cuenta y riesgo de los mismos, en bienes
+    inmuebles, valores o cualquier derecho de contenido económico, dependiendo de la
+    naturaleza del fondo, y cuyos rendimientos se establecen en función de los resultados del
+    mismo.
+14) Grupo financiero. Es la sociedad controladora que integra a personas jurídicas que
+    mantienen preponderantemente actividades de índole financiera, impliquen éstas
+    intermediación o no, actividades de apoyo, conexas o coligadas y que presentan vínculos de
+    propiedad, administración, parentesco o control, en la cual la actuación económica y
+    financiera de sus integrantes, está guiada por intereses comunes del grupo o subordinada a
+    éstos.
+15) Hecho relevante. Es el hecho o evento respecto de un participante del mercado y de su
+    grupo financiero, que pudiera afectar positiva o negativamente su posición jurídica,
+    económica o financiera, o el precio de los valores en el mercado.
+16) Información confidencial: Es la información que por su naturaleza o posible impacto debe
+    ser manejada con estricta discreción, por parte de los Miembros del Consejo Nacional del
+    Mercado de Valores, los funcionarios y el personal de la Superintendencia.
+17) Información no-pública: Es la información no incluida en el alcance de la Ley No.200-04
+    General de Libre Acceso a la Información Pública, de fecha 28 de julio de 2004.
+18) Información privilegiada. Es la información referida a uno o varios participantes del
+    mercado, a sus negocios, a sus valores de oferta pública o al mercado que pudiera afectar su
+    posición jurídica, económica o financiera, cuando no sea de dominio público.
+19) Información reservada. Es la información privilegiada que se encuentra fuera del acceso
+    público, debido a que su difusión puede poner en riesgo la estabilidad o seguridad financiera
+    del mercado de valores o sus participantes.
+20) Instrumentos derivados. Es la operación, contrato o convención, estandarizado o no, cuyo
+    resultado financiero deriva o está condicionado a la variación o evolución del precio o
+    rentabilidad de uno o varios activos subyacentes financieros o no financieros.
+21) Inversionistas institucionales. Son las entidades de intermediación financiera, sociedades
+    de seguros y reaseguros, las administradoras de fondos de pensiones, sociedades
+    administradoras de fondos de inversión, los intermediarios de valores, sociedades fiduciarias,
+    sociedades titularizadoras, así como toda persona jurídica legalmente autorizada para
+    administrar recursos de terceros, para fines de inversión principalmente a través del mercado
+    de valores.
+22) Inversionistas profesionales. Son los inversionistas institucionales y aquellas personas
+    físicas o jurídicas, debidamente reconocidas por la Superintendencia del Mercado de Valores,
+    -6-
+    que realizan habitualmente operaciones con valores de oferta pública o que por su profesión,
+    experiencia, conocimiento, actividad o patrimonio, se puede presumir que poseen un alto
+    conocimiento del mercado de valores.
+23) Ley de Sociedades. Es la Ley No.479-08, General de las Sociedades Comerciales y
+    Empresas Individuales de Responsabilidad Limitada, de fecha 11 de diciembre de 2008 y
+    sus modificaciones.
+24) Ley de Fideicomiso. Es la Ley No.189-11, para el Desarrollo del Mercado Hipotecario y el
+    Fideicomiso en la República Dominicana, de fecha 16 de julio de 2011.
+25) Manipulación de mercado. Es el acto realizado por una o varias personas, tanto físicas
+    como jurídicas, a través del cual se interfiera o influya en la libre interacción entre oferta y
+    demanda, haciendo variar artificialmente el volumen o precio de valores de oferta pública,
+    con la finalidad de obtener un beneficio propio o de terceros, así como divulgar
+    información falsa o engañosa al mercado con este propósito.
+26) Mecanismos centralizados de negociación. Son sistemas multilaterales y transaccionales,
+    que mediante un conjunto determinado de reglas de admisión, cotización, actuación,
+    transparencia y convergencia de participantes, reúnan o interconecten simultáneamente a
+    varios compradores y vendedores, con el objeto de negociar valores de oferta pública y
+    divulgar información al mercado sobre dichas operaciones.
+27) Mercado OTC. Es el mercado que se desarrolla fuera de los mecanismos centralizados de
+    negociación con valores de oferta pública de acuerdo a lo establecido en esta ley.
+28) Mercado de Valores. Es el mercado que comprende la oferta y demanda de valores
+    organizado en mecanismos centralizados de negociación y en el Mercado OTC, para permitir
+    el proceso de emisión, colocación y negociación de valores de oferta pública inscritos en el
+    Registro del Mercado de Valores, bajo la supervisión de la Superintendencia.
+29) Mercado Primario de Valores. Es aquel en el que las emisiones de valores de oferta pública
+    son colocadas por primera vez en el mercado de valores para financiar las actividades de los
+    emisores.
+30) Mercado Secundario de Valores. Es el que comprende todas las transacciones, operaciones
+    y negociaciones de valores de oferta pública, emitidos y colocados previamente.
+31) Oferta pública. Es todo ofrecimiento, directo o indirecto, realizado por cualquier persona al
+    público en general o a sectores o grupos específicos de éste, a través de cualquier medio de
+    comunicación o difusión, para que suscriban, adquieran, enajenen o negocien
+    individualmente un número indeterminado de valores.
+32) Originador. Es la persona propietaria de bienes o activos sobre los que puede actuar
+    libremente, para transferirlos irrevocablemente a una sociedad titularizadora para el
+    desarrollo de un proceso de titularización.
+    -7-
+33) Participante del mercado de valores. Es la persona física o jurídica, inscrita en el Registro
+    del Mercado de Valores y regulada por la Superintendencia del Mercado de Valores.
+34) Patrimonio autónomo. Es el patrimonio de propósito exclusivo, sin personalidad jurídica,
+    inembargable, independiente y separado, tanto jurídica como contablemente, del patrimonio,
+    tanto de la persona jurídica que lo administra como de cualquier otro patrimonio que ésta
+    administre.
+35) Patrimonio separado. Es un patrimonio autónomo constituido por una sociedad
+    titularizadora dentro de un proceso de titularización.
+36) Promotor de inversión. Es la persona física o jurídica que cumple la función principal de
+    orientar a potenciales aportantes para la adquisición de cuotas de los fondos de inversión
+    abiertos.
+37) Prospecto de emisión. Es un documento escrito de carácter público que contiene las
+    características concretas de los valores que se ofrecen y, en general, los datos e información
+    relevante respecto del emisor y de los intervinientes del proceso de oferta pública.
+38) Sistema de anotación en cuenta. Es el mecanismo que tiene por objeto establecer el registro
+    de los valores de las sociedades autorizadas, mediante anotaciones en cuenta, la adquisición y
+    la transmisión de propiedad de los mismos, mediante cargos y abonos contables efectuados
+    por un depósito centralizado de valores, según las instrucciones de los participantes
+    autorizados para tales fines.
+39) Sociedades cotizadas. Son sociedades anónimas cuyas acciones estén admitidas a
+    negociación en una bolsa de valores.
+40) Titularización. Es el proceso que consiste en el agrupamiento o empaquetamiento de bienes
+    o activos generadores de flujos de caja, mediante la creación de un patrimonio separado
+    administrado por una sociedad titularizadora, o de un fideicomiso de oferta pública
+    administrado por un fiduciario autorizado.
+41) Valor. Es un derecho o conjunto de derechos de contenido esencialmente económico, que
+    incorpora un derecho literal y autónomo que se ejercita por su titular legitimado. Quedan
+    comprendidos dentro de este concepto, los instrumentos derivados que se inscriban en el
+    Registro del Mercado de Valores.
+42) Valores de renta variable. Son valores que otorgan a sus titulares, derechos o partes
+    alícuotas de participación sobre el patrimonio del emisor a prorrata de la inversión, siendo el
+    rendimiento variable en forma de ganancias de capital o distribuciones periódicas de
+    dividendos, según la política de dividendos establecida.
+43) Valores de renta fija. Son valores representativos de deuda procedentes del pasivo del
+    emisor, cuyo rendimiento no depende de sus resultados financieros, por lo que le representan
+    -8-
+    una obligación de restituir el capital invertido más un rendimiento predeterminado, en los
+    términos y condiciones señalados en el respectivo valor

--- a/workshop/exercise-1.md
+++ b/workshop/exercise-1.md
@@ -198,7 +198,8 @@ public String chat(@RequestParam String message, @RequestParam(defaultValue = "f
 
 ## Solución
 
-TODO
+[Ir a la siguiente rama de git - jconfdominicana2025-exercise-1-solution](https://github.com/xTryHard/optimizing-llm-responses-with-rag-in-java/tree/jconfdominicana2025-exercise-1-solution)
+
 
 ## Hora de probar tu primer prompt
 

--- a/workshop/exercise-2.md
+++ b/workshop/exercise-2.md
@@ -35,10 +35,9 @@ Para que el asistente pueda recordar múltiples conversaciones con diferentes us
 
 Modificaremos nuestro `ChatController` para que inyecte el objeto `HttpSession` de Spring. Usaremos el ID de la sesión (`session.getId()`) como el `conversationId` que pasaremos a nuestro servicio.
 
-Nota: estamos usando `spring-session-jdbc` para persistir el id de la sesion.
 ```java
-    // src/main/java/com/theitdojo/optimizing_llm_responses_with_rag_in_java/controllers/ChatController.java
-import jakarta.servlet.http.HttpSession; // ¡Asegúrate de importar HttpSession!
+// src/main/java/com/theitdojo/optimizing_llm_responses_with_rag_in_java/controllers/ChatController.java
+import jakarta.servlet.http.HttpSession; // Asegúrate de importar HttpSession
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 // ... otras importaciones

--- a/workshop/exercise-2.md
+++ b/workshop/exercise-2.md
@@ -247,7 +247,7 @@ public class ChatConfig {
     public ChatMemory chatMemory(ChatMemoryRepository chatMemoryRepository) {
         return MessageWindowChatMemory.builder()
                 .chatMemoryRepository(chatMemoryRepository)
-                .maxMessages(5) // Limita el historial a los últimos 5 mensajes
+                .maxMessages(10) // Limita el historial a los últimos 10 mensajes
                 .build();
     }
 }
@@ -293,9 +293,13 @@ Habla siempre en español.
 /no_think
 ```
 
+Luego de actualizar el `system-prompt.md` si deseas puedes volver a ejecutar los pasos anteriores en la sección __Hora de probar la memoria del asistente (Persistente)__.
+Esto no es estrictamente necesario, vamos a poder probar esto y otras funcionalidades en los siguientes ejercicios.
+
+
 ## Solución
 
-TODO
+[Ir a la siguiente rama de git - jconfdominicana2025-exercise-2-solution](https://github.com/xTryHard/optimizing-llm-responses-with-rag-in-java/tree/jconfdominicana2025-exercise-2-solution)
 
 ## Conclusión
 

--- a/workshop/exercise-2.md
+++ b/workshop/exercise-2.md
@@ -33,11 +33,10 @@ Para que el asistente pueda recordar múltiples conversaciones con diferentes us
 
 2 __Actualizar el Controlador__ `ChatController`
 
-Modificaremos nuestro `ChatController` para que inyecte el objeto `HttpSession` de Spring. Usaremos el ID de la sesión (`session.getId()`) como el `conversationId` que pasaremos a nuestro servicio.
+Vamos a colocar un valor fijo como identificador de la conversación, esto simula la estrategia de identificación utilizada en tu propio sistema.
 
 ```java
 // src/main/java/com/theitdojo/optimizing_llm_responses_with_rag_in_java/controllers/ChatController.java
-import jakarta.servlet.http.HttpSession; // Asegúrate de importar HttpSession
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 // ... otras importaciones
@@ -54,9 +53,9 @@ public class ChatController {
     }
 
     @GetMapping("/chat")
-    public String chat(HttpSession session, @RequestParam String message, @RequestParam(defaultValue = "false") boolean stream) {
-        // Usamos el ID de la sesión como ID de la conversación
-        Stream<String> responseStream = chatAssistant.askQuestion(session.getId(), message, stream);
+    public String chat(@RequestParam String message, @RequestParam(defaultValue = "false") boolean stream) {
+        // El valor fijo en CONVERSATION_ID simula el identificador utilizado en tu sistema para tus usuarios.
+        Stream<String> responseStream = chatAssistant.askQuestion("CONVERSATION_ID", message, stream);
 
         StringBuilder responseBuilder = new StringBuilder();
 

--- a/workshop/exercise-2.md
+++ b/workshop/exercise-2.md
@@ -34,6 +34,8 @@ Para que el asistente pueda recordar múltiples conversaciones con diferentes us
 2 __Actualizar el Controlador__ `ChatController`
 
 Modificaremos nuestro `ChatController` para que inyecte el objeto `HttpSession` de Spring. Usaremos el ID de la sesión (`session.getId()`) como el `conversationId` que pasaremos a nuestro servicio.
+
+Nota: estamos usando `spring-session-jdbc` para persistir el id de la sesion.
 ```java
     // src/main/java/com/theitdojo/optimizing_llm_responses_with_rag_in_java/controllers/ChatController.java
 import jakarta.servlet.http.HttpSession; // ¡Asegúrate de importar HttpSession!
@@ -71,65 +73,48 @@ public class ChatController {
 
 ### Parte 2 - Implementando ChatMemory en Memoria (In-Memory)
 
-Comenzaremos con la implementación más simple: `InMemoryChatMemory`.
+Registraremos un `MessageChatMemoryAdvisor`, primero agregamos las siguientes importaciones:
+
+```java
+import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
+import org.springframework.ai.chat.memory.ChatMemory;
+```
 
 1. Actualizar `ChatAssistantService`
 
-Modifica el constructor de `ChatAssistantService` para que también inyecte un bean de `ChatMemory`. Luego, configura el `ChatClient.Builder` para que use esta memoria por defecto.
+Modifica el constructor de `ChatAssistantService` para que también inyecte un bean de `ChatMemory`. Luego, agregamos un advisor predeterminado desde `MessageChatMemoryAdvisor.builder()`
 
 ```java
     // src/main/java/com/theitdojo/optimizing_llm_responses_with_rag_in_java/services/ChatAssistantService.java
-    import org.springframework.ai.chat.memory.ChatMemory;
-    // ...
 
-    @Service
-    public class ChatAssistantService implements ChatAssistant {
+import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
+import org.springframework.ai.chat.memory.ChatMemory;
+// ...
 
-       private final ChatClient chatClient;
-       private final ChatMemory chatMemory;
+@Service
+public class ChatAssistantService implements ChatAssistant {
 
-       public ChatAssistantService(ChatClient.Builder builder,
-                                   @Value("classpath:/system-prompt.md") Resource systemPrompt,
-                                   ChatMemory chatMemory) { // Inyectar ChatMemory
-          this.chatMemory = chatMemory;
-          this.chatClient = builder
-                  .defaultSystem(systemPrompt)
-                  .build();
-       }
-       // ... El resto de la clase
+    private final ChatClient chatClient;
+    private final ChatMemory chatMemory;
+
+    public ChatAssistantService(ChatClient.Builder builder,
+                                @Value("classpath:/system-prompt.md") Resource systemPrompt,
+                                ChatMemory chatMemory) {
+        this.chatMemory = chatMemory;
+        this.chatClient = builder
+                .defaultSystem(systemPrompt)
+                .defaultAdvisors(MessageChatMemoryAdvisor.builder(chatMemory).build())
+                .build();
     }
-    
+    // ... El resto de la clase
+}
+
 ```
-2. Crear el Bean de `ChatMemory`
+2. Especificar el ID de la Conversación para el Advisor
 
-Por defecto, Spring AI no crea un bean de _ChatMemory_. Vamos a crear una clase de configuración para proveer una instancia de _InMemoryChatMemory_.
+Aunque ya registramos un `advisor` de memoria en el constructor, este no sabe mágicamente a qué conversación pertenece cada nueva solicitud. Por ello, en cada método que interactúa con el `ChatClient`, debemos pasar explícitamente el `conversationId`. Esto le indica al `MessageChatMemoryAdvisor` qué historial de conversación debe cargar y actualizar para esta interacción en particular.
 
-Crea un nuevo paquete `config` y dentro una clase `ChatConfig`.
-
-```java
-    // src/main/java/com/theitdojo/optimizing_llm_responses_with_rag_in_java/config/ChatConfig.java
-    package com.theitdojo.optimizing_llm_responses_with_rag_in_java.config;
-
-    import org.springframework.ai.chat.memory.ChatMemory;
-    import org.springframework.ai.chat.memory.InMemoryChatMemory;
-    import org.springframework.context.annotation.Bean;
-    import org.springframework.context.annotation.Configuration;
-
-    @Configuration
-    public class ChatConfig {
-
-        @Bean
-        public ChatMemory chatMemory() {
-            return new InMemoryChatMemory();
-        }
-    }
-```
-
-3. Usar la Memoria en las Llamadas al LLM
-
-Ahora, actualiza los métodos de `ChatAssistantService` para que utilicen el `conversationId` y la `chatMemory` en cada llamada. 
-
-Esto se hace encadenando `.chatReference(conversationId)` y `.chatMemory(chatMemory)` en la llamada al `prompt`. No olvides actualizar las firmas de los métodos para que coincidan con la interfaz.
+Ahora, actualicemos los métodos de ChatAssistantService para pasar este identificador:
 
 ```java
     // Dentro de ChatAssistantService.java
@@ -137,8 +122,7 @@ Esto se hace encadenando `.chatReference(conversationId)` y `.chatMemory(chatMem
     @Override
     public String getResponse(String conversationId, String message) {
         return this.chatClient.prompt()
-                .chatReference(conversationId) // Identifica la conversación
-                .chatMemory(this.chatMemory)   // Usa la memoria
+                .advisors(advisor -> advisor.param(ChatMemory.CONVERSATION_ID, conversationId))
                 .user(message)
                 .call()
                 .content();
@@ -147,60 +131,81 @@ Esto se hace encadenando `.chatReference(conversationId)` y `.chatMemory(chatMem
     @Override
     public Stream<String> streamResponse(String conversationId, String message) {
         return chatClient.prompt()
-                .chatReference(conversationId) // Identifica la conversación
-                .chatMemory(this.chatMemory)   // Usa la memoria
                 .user(message)
+                .advisors(advisor -> advisor.param(ChatMemory.CONVERSATION_ID, conversationId))
                 .stream()
                 .content()
                 .toStream();
     }
     
-    // ... Asegúrate de actualizar también askQuestion y askQuestionWithContext
+
+    @Override
+    public Stream<String> askQuestionWithContext(String conversationId, String question) {
+        // TODO: Implementar la lógica de RAG en un futuro ejercicio.
+        return chatClient.prompt()
+                .user(question)
+                .advisors(advisor -> advisor.param(ChatMemory.CONVERSATION_ID, conversationId))
+                .stream()
+                .content()
+                .toStream();
+    }
 ```
 
-## Hora de probar la memoria del asistente (In-Memory)
-
-Para apreciar realmente el valor de la persistencia, vamos a realizar pruebas en dos fases.
-
-### Fase 1: Probando la Memoria Volátil (con InMemoryChatMemory)
+## Probando la Memoria Volátil (con MessageChatMemoryAdvisor)
 
 Antes de cambiar a la memoria persistente, primero vamos a verificar el comportamiento de la implementación en memoria que configuraste en la Parte 2.
 
-1. Asegúrate de que tu `ChatConfig` esté proveyendo el bean de `InMemoryChatMemory`. Si ya lo cambiaste, vuelve a ponerlo temporalmente.
-
-```java
-// En ChatConfig.java
-@Bean
-public ChatMemory chatMemory() {
-    return new InMemoryChatMemory();
-}
-```
-
-2. Ejecuta la aplicación.
-3.  Abre tu navegador y haz una pregunta inicial: `http://localhost:8080/ai/chat?message=Mi nombre es Fulano. ¿Puedes decirme qué es Spring AI?`.
-4. En la misma pestaña (misma sesión), pregunta: `http://localhost:8080/ai/chat?message=¿Recuerdas mi nombre?`
+1. Ejecuta la aplicación.
+2. Abre tu navegador y haz una pregunta inicial: `http://localhost:8080/ai/chat?message=Mi nombre es Fulano. ¿Puedes decirme qué es Spring AI?`.
+3. En la misma pestaña (misma sesión), pregunta: `http://localhost:8080/ai/chat?message=¿Cuál es mi nombre?, `
     - __Resultado esperado__: El asistente responderá correctamente "Fulano", demostrando que la memoria funciona dentro de la sesión de la aplicación.
 
-5. Reinicia tu aplicación Spring Boot.
-6. Una vez reiniciada, en la misma pestaña del navegador, vuelve a preguntar: `http://localhost:8080/ai/chat?message=¿Recuerdas mi nombre?`
+4. Reinicia tu aplicación Spring Boot.
+5. Una vez reiniciada, en la misma pestaña del navegador, vuelve a preguntar: `http://localhost:8080/ai/chat?message=¿Cuál es mi nombre?`
     - __Resultado esperado__: El asistente NO recordará tu nombre. Esto demuestra la naturaleza volátil de `InMemoryChatMemory`: la memoria se borra cuando la aplicación se detiene.
-
-
 
 
 
 ### Parte 3 - Implementando Memoria Persistente con PostgreSQL y JDBC
 
-La memoria en memoria es útil, pero se pierde al reiniciar. Para una aplicación real, necesitamos persistencia. Ya que tienes PostgreSQL configurado, vamos a utilizarlo para almacenar el historial de chat. Gracias a la autoconfiguración de Spring AI, este cambio es sorprendentemente fácil.
+Almacenar información en memoria es útil, pero se pierde al reiniciar. Para una aplicación real, necesitamos persistencia. `JdbcChatMemoryRepository` es una implementación que utiliza JDBC para guardar los mensajes en una base de datos relacional, ideal para aplicaciones que requieren que el historial de chat sobreviva a los reinicios.
 
-1. Verificar Dependencias
+1. Agregar dependencia `spring-ai-starter-model-chat-memory-repository-jdbc` 
 
-En tu `pom.xml`, asegúrate que se incluya:
+En tu `pom.xml` agrega la siguiente dependencia
 
+```xml
+<dependency>
+    <groupId>org.springframework.ai</groupId>
+    <artifactId>spring-ai-starter-model-chat-memory-repository-jdbc</artifactId>
+</dependency>
+```
+
+2. Verificar Dependencias
+
+En tu `pom.xml`, asegúrate de que las siguientes dependencias estén incluidas. La nueva dependencia clave aquí es  `spring-ai-starter-model-chat-memory-repository-jdbc`, que nos proporciona la autoconfiguración para la memoria de chat con JDBC.
+```xml
+<dependency>
+    <groupId>org.springframework.ai</groupId>
+    <artifactId>spring-ai-starter-model-chat-memory-repository-jdbc</artifactId>
+</dependency>
+        
+<dependency>
+<groupId>org.springframework.boot</groupId>
+<artifactId>spring-boot-starter-data-jpa</artifactId>
+</dependency>
+
+<dependency>
+<groupId>org.postgresql</groupId>
+<artifactId>postgresql</artifactId>
+<scope>runtime</scope>
+</dependency>
+```
+- `spring-ai-starter-model-chat-memory-repository-jdbc`: Proporciona la autoconfiguración para `JdbcChatMemoryRepository`
 - `spring-boot-starter-data-jpa`: Que a su vez incluye `spring-boot-starter-jdbc`, necesario para `JdbcChatMemoryRepository`.
 - `postgresql`: El driver JDBC para conectarse a tu base de datos. 
 
-2. Verificar la Configuración de la Base de Datos
+3. Verificar la Configuración de la Base de Datos
 
 En tu `application.properties` asegúrate que se incluya:
 
@@ -211,62 +216,59 @@ En tu `application.properties` asegúrate que se incluya:
     spring.datasource.password=postgres
     spring.datasource.driver-class-name=org.postgresql.Driver
     spring.jpa.hibernate.ddl-auto=update
+    spring.ai.chat.memory.repository.jdbc.initialize-schema=always
 ```
+La propiedad `spring.ai.chat.memory.repository.jdbc.initialize-schema=always` le indica a Spring AI que cree la tabla spring_ai_chat_memory si no existe al arrancar.
 
-3. Aprovechar las bondades de la Autoconfiguración de Spring Boot 
+4. Configurar un Bean de `MessageWindowChatMemory`
 
-El siguiente paso es idéntico independientemente de la base de datos subyacente. Simplemente necesitamos declarar un bean `ChatMemory` que utilice el `ChatMemoryRepository` que Spring AI autoconfigura para nosotros al detectar un `DataSource`.
+Ahora, en lugar de una memoria simple, crearemos una `ChatMemory` más avanzada que solo considera las últimas interacciones. Esto se conoce como "memoria de ventana" (window memory) y es crucial para evitar enviar un historial de conversación demasiado largo al LLM, lo que consumiría muchos tokens y aumentaría los costos.
 
-Modifica el bean de `ChatMemory` en tu `ChatConfig` para que Spring inyecte el `JdbcChatMemoryRepository` autoconfigurado.
+Spring AI autoconfigura un bean `JdbcChatMemoryRepository` porque detecta el starter de JDBC y una `DataSource` activa. Simplemente lo inyectamos y lo usamos para construir nuestra `ChatMemory`.
 
+Crea un nuevo paquete `config` y, dentro, una clase `ChatConfig`.
 ```java
-    // src/main/java/com/theitdojo/optimizing_llm_responses_with_rag_in_java/config/ChatConfig.java
-    import org.springframework.ai.chat.memory.ChatMemory;
-    import org.springframework.ai.chat.memory.JdbcChatMemory; // Importar
-    import org.springframework.ai.chat.memory.ChatMemoryRepository; // Importar
-    import org.springframework.context.annotation.Bean;
-    import org.springframework.context.annotation.Configuration;
+// src/main/java/com/theitdojo/optimizing_llm_responses_with_rag_in_java/config/ChatConfig.java
+package com.theitdojo.optimizing_llm_responses_with_rag_in_java.config;
 
-    @Configuration
-    public class ChatConfig {
+import org.springframework.ai.chat.memory.ChatMemory;
+import org.springframework.ai.chat.memory.ChatMemoryRepository;
+import org.springframework.ai.chat.memory.MessageWindowChatMemory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
-        // Spring AI autoconfigura un JdbcChatMemoryRepository porque ve
-        // spring-boot-starter-jdbc en el classpath y un DataSource configurado.
-        // Nosotros solo necesitamos crear el bean de ChatMemory que lo use.
-        @Bean
-        public ChatMemory chatMemory(ChatMemoryRepository repository) { // Inyectamos el repositorio autoconfigurado
-            return new JdbcChatMemory(repository);
-        }
+@Configuration
+public class ChatConfig {
+
+    /**
+     * Spring AI autoconfigura un JdbcChatMemoryRepository porque ve
+     * spring-ai-starter-model-chat-memory-repository-jdbc en el classpath y un DataSource configurado.
+     * Nosotros solo necesitamos inyectarlo y crear el bean de ChatMemory que lo use.
+     */
+    @Bean
+    public ChatMemory chatMemory(ChatMemoryRepository chatMemoryRepository) {
+        return MessageWindowChatMemory.builder()
+                .chatMemoryRepository(chatMemoryRepository)
+                .maxMessages(5) // Limita el historial a los últimos 5 mensajes
+                .build();
     }
-    
-```
-
-Con este cambio, tu aplicación ahora persistirá todo el historial de chat en tu base de datos PostgreSQL. Al iniciar, Spring AI creará automáticamente la tabla chat_memory si no existe.
-
-## Hora de probar la memoria del asistente (Persistente)
-
-### Fase 2: Probando la Memoria Persistente (con `JdbcChatMemory`)
-
-Ahora, volvamos a la configuración de la Parte 3 para ver la diferencia.
-
-1. Asegúrate de que tu `ChatConfig` esté proveyendo el bean de `JdbcChatMemory`. inyectando el `ChatMemoryRepository`.
-
-```java
-// En ChatConfig.java
-@Bean
-public ChatMemory chatMemory(ChatMemoryRepository repository) {
-    return new JdbcChatMemory(repository);
 }
 ```
 
-2. Ejecuta la aplicación.
-3. Abre tu navegador y haz una pregunta para establecer contexto: `http://localhost:8080/ai/chat?message=Mi nombre es Fulano. ¿Puedes decirme qué es Spring AI?`.
-4. En la misma pestaña, haz una pregunta de seguimiento que dependa del contexto: `http://localhost:8080/ai/chat?message=¿Podrías darme un ejemplo de código simple sobre eso?`
-5. Finalmente, prueba si recuerda tu nombre: `http://localhost:8080/ai/chat?message=¿Recuerdas cómo me llamo?`
+Con este cambio, tu aplicación ahora persistirá el historial de chat en PostgreSQL, pero solo enviará el contexto más reciente al LLM en cada solicitud, manteniendo las conversaciones eficientes y relevantes.
+
+## Hora de probar la memoria del asistente (Persistente)
+
+Ahora, volvamos a la configuración de la Parte 3 para ver la diferencia.
+
+1. Ejecuta la aplicación.
+2. Abre tu navegador y haz una pregunta para establecer contexto: `http://localhost:8080/ai/chat?message=Mi nombre es Fulano. ¿Puedes decirme qué es Spring AI?`.
+3. En la misma pestaña, haz una pregunta de seguimiento que dependa del contexto: `http://localhost:8080/ai/chat?message=¿Podrías darme un ejemplo de código simple sobre eso?`
+4. Finalmente, prueba si recuerda tu nombre: `http://localhost:8080/ai/chat?message=¿Recuerdas cómo me llamo?`
     - __Resultado esperado__: El asistente __recordará__ tu nombre.
 
-6. Reinicia tu aplicación Spring Boot.
-7. Una vez reiniciada, en la misma pestaña del navegador, vuelve a preguntar: `http://localhost:8080/ai/chat?message=¿Recuerdas mi nombre?`
+5. Reinicia tu aplicación Spring Boot.
+6. Una vez reiniciada, en la misma pestaña del navegador, vuelve a preguntar: `http://localhost:8080/ai/chat?message=¿Recuerdas mi nombre?`
     - __Resultado esperado__: El asistente __SÍ__ recordará tu nombre. La conversación sobrevivió al reinicio de la aplicación gracias a la persistencia en la base de datos PostgreSQL.
 
 #### Verificando la Persistencia en la Base de Datos
@@ -275,7 +277,7 @@ public ChatMemory chatMemory(ChatMemoryRepository repository) {
 2. Ejecuta la siguiente consulta SQL:
 
 ```sql
-SELECT * FROM chat_memory;
+SELECT * FROM spring_ai_chat_memory;
 ```
 Verás las filas que representan el historial de la conversación que acabas de tener.
 
@@ -309,9 +311,10 @@ En este ejercicio, hemos dado un paso crucial para transformar nuestro asistente
 
 ### Cómo nos ayudó Spring AI
 
--   **Abstracción `ChatMemory`**: Spring AI nos ha facilitado enormemente la tarea con su abstracción `ChatMemory`. En lugar de implementar la lógica de almacenamiento y recuperación desde cero, simplemente utilizamos sus implementaciones listas para usar.
+-   **Abstracción `ChatMemory`**: La integración de la memoria en nuestras llamadas al `ChatClient` fue increíblemente sencilla. Al configurar un `MessageChatMemoryAdvisor` por defecto y luego especificar el `conversationId` en cada llamada con el método `.advisors()`, mantuvimos nuestro código limpio y legible.
 -   **API Fluida e Integrada**: La integración de la memoria en nuestras llamadas al `ChatClient` fue increíblemente sencilla gracias a los métodos `.chatReference()` y `.chatMemory()`, manteniendo nuestro código limpio y legible.
 -   **Bondades de la Autoconfiguración**: El cambio de una memoria volátil a una persistente con una base de datos PostgreSQL fue sorprendentemente simple. Gracias a la autoconfiguración de Spring Boot, Spring AI detectó nuestra configuración de base de datos y proveyó automáticamente el `JdbcChatMemoryRepository`, demostrando el poder del ecosistema de Spring para reducir el código repetitivo.
 
 ### Próximo ejercicio
-    
+
+[Ejercicio 3: Interfaz de Usuario (UI) Reactiva con Vaadin](./exercise-3.md)

--- a/workshop/exercise-3.md
+++ b/workshop/exercise-3.md
@@ -102,7 +102,8 @@ Con el backend y el frontend listos y conectados, es hora de ver nuestro chatbot
 
 ## Solución
 
-TODO
+[Ir a la siguiente rama de git - jconfdominicana2025-exercise-3-solution](https://github.com/xTryHard/optimizing-llm-responses-with-rag-in-java/tree/jconfdominicana2025-exercise-3-solution
+)
 
 ## Conclusión
 

--- a/workshop/exercise-3.md
+++ b/workshop/exercise-3.md
@@ -73,8 +73,7 @@ La nueva `ChatView` de Vaadin está diseñada para consumir un `Flux<String>` de
         // TODO: Implementar la lógica de RAG en un futuro ejercicio.
         // Cambiamos a Flux para soportar el streaming reactivo hacia la UI de Vaadin.
         return this.chatClient.prompt()
-                .chatReference(conversationId)
-                .chatMemory(this.chatMemory)
+                .advisors(advisor -> advisor.param(ChatMemory.CONVERSATION_ID, conversationId))
                 .user(question)
                 .stream()
                 .content();

--- a/workshop/exercise-4.md
+++ b/workshop/exercise-4.md
@@ -1,0 +1,213 @@
+# Ejercicio 4: Generación Aumentada por Recuperación (RAG) - El Enfoque Manual
+
+En los ejercicios anteriores, construimos un asistente que puede mantener una conversación, pero su conocimiento se limita a lo que aprendió durante su entrenamiento. No puede responder preguntas sobre datos específicos de una empresa, documentos recientes o cualquier información que no sea de dominio público.
+
+Aquí es donde entra en juego la **Generación Aumentada por Recuperación (RAG)**. RAG es una técnica poderosa que permite a los LLMs acceder a información externa y actualizada en el momento de la consulta. En lugar de simplemente responder desde su memoria interna, el sistema primero "recupera" información relevante de una fuente de datos (como documentos, bases de datos, etc.) y luego la "aumenta" al prompt, dándole al LLM el contexto necesario para generar una respuesta precisa.
+
+En este ejercicio, implementaremos una versión muy básica y manual de RAG. No usaremos una base de datos de vectores todavía; en su lugar, cargaremos un documento de texto completo en la memoria y lo inyectaremos directamente en el prompt. Utilizaremos el archivo `src/main/resources/simv/glosario.txt`, que contiene un glosario de términos del mercado de valores.
+
+Este enfoque nos permitirá responder preguntas sobre el glosario, pero también revelará sus importantes limitaciones en cuanto a eficiencia y escalabilidad, preparando el terreno para la solución RAG optimizada que construiremos en el siguiente ejercicio.
+
+## Manos a la obra
+
+### Parte 1 - Actualizar la Interfaz `ChatAssistant`
+
+Primero, vamos a añadir un nuevo método a nuestra interfaz `ChatAssistant` que se encargará específicamente de las preguntas que requieren contexto externo.
+
+Añade la siguiente firma de método a la interfaz `ChatAssistant.java`:
+
+```java
+// src/main/java/com/theitdojo/optimizing_llm_responses_with_rag_in_java/services/ChatAssistant.java
+
+public interface ChatAssistant {
+    // ... métodos existentes de ejercicios anteriores
+    Stream<String> askQuestionWithContext(String conversationId, String question);
+}
+```
+Nota: Dependiendo de tu progreso en los ejercicios anteriores, este método ya podría existir. Asegúrate de que la firma coincida.
+
+### Parte 2 - Crear un `PromptTemplate` para el Contexto
+
+Para inyectar nuestro contexto de manera estructurada, usaremos un `PromptTemplate` de Spring AI. Un `PromptTemplate` nos permite definir una plantilla para nuestros prompts con marcadores de posición que se rellenan dinámicamente.
+
+En nuestra clase `ChatConfig`, crearemos un bean para un `PromptTemplate` que instruya al modelo sobre cómo usar el contexto.
+
+1. Crea el archivo de plantilla: Primero, crea un nuevo archivo llamado `rag-prompt-template.st` en la carpeta `src/main/resources`. El `.st` es por "StringTemplate", el formato que usa Spring AI.
+
+```st
+// src/main/resources/rag-prompt-template.st
+Usa el siguiente contexto para responder la pregunta al final.
+Si la respuesta no puede ser encontrada en el contexto, indica amablemente que no tienes la información para responder esa pregunta.
+No añadas ninguna otra información adicional.
+
+Contexto:
+{context}
+
+Pregunta:
+{question}    
+```
+
+2. Crea el Bean del `PromptTemplate`: Ahora, en tu clase `ChatConfig`, crea un bean que cargue esta plantilla.
+
+```java
+    // src/main/java/com/theitdojo/optimizing_llm_responses_with_rag_in_java/config/ChatConfig.java
+    import org.springframework.ai.chat.prompt.PromptTemplate;
+    import org.springframework.beans.factory.annotation.Value;
+    import org.springframework.core.io.Resource;
+    // ...
+
+    @Configuration
+    public class ChatConfig {
+
+        // ... bean de ChatMemory existente
+
+        @Bean
+        public PromptTemplate ragPromptTemplate(@Value("classpath:/rag-prompt-template.st") Resource ragPromptTemplate) {
+            return new PromptTemplate(ragPromptTemplate);
+        }
+    }
+```
+
+### Parte 3 - Cargar el Contexto y Usar el Template
+
+Ahora, modificaremos `ChatAssistantService` para cargar el contenido del `glosario.txt` y usar nuestro nuevo `PromptTemplate` para responder.
+
+1. __Cargar el archivo de glosario__: En `ChatAssistantService`, inyectaremos el archivo del glosario como un `Resource` y lo leeremos como un `String` en el constructor.
+2. __Implementar__ `askQuestionWithContext`: Implementaremos el método que dejamos pendiente. Inyectaremos el `PromptTemplate` que acabamos de crear. Luego, usaremos este template para construir un `Prompt` con el contexto del glosario y la pregunta del usuario.
+
+Actuaiza tu `ChatAssistantService.java` para que se vea así: 
+
+```java
+    package com.theitdojo.optimizing_llm_responses_with_rag_in_java.services;
+
+    import org.springframework.ai.chat.client.ChatClient;
+    import org.springframework.ai.chat.memory.ChatMemory;
+    import org.springframework.ai.chat.prompt.Prompt;
+    import org.springframework.ai.chat.prompt.PromptTemplate;
+    import org.springframework.beans.factory.annotation.Value;
+    import org.springframework.core.io.Resource;
+    import org.springframework.stereotype.Service;
+
+    import java.io.IOException;
+    import java.nio.charset.StandardCharsets;
+    import java.util.Map;
+    import java.util.stream.Stream;
+
+    @Service
+    public class ChatAssistantService implements ChatAssistant {
+
+        private final ChatClient chatClient;
+        private final ChatMemory chatMemory;
+        private final PromptTemplate ragPromptTemplate;
+        private final String glossaryContext;
+
+        public ChatAssistantService(ChatClient.Builder builder,
+                                    @Value("classpath:/system-prompt.md") Resource systemPrompt,
+                                    ChatMemory chatMemory,
+                                    PromptTemplate ragPromptTemplate, // Inyectar el PromptTemplate
+                                    @Value("classpath:/simv/glosario.txt") Resource glossaryResource) throws IOException { // Inyectar el glosario
+            this.chatMemory = chatMemory;
+            this.ragPromptTemplate = ragPromptTemplate;
+            this.chatClient = builder
+                    .defaultSystem(systemPrompt)
+                    .build();
+
+            // Cargar el contenido del glosario a un String
+            this.glossaryContext = glossaryResource.getContentAsString(StandardCharsets.UTF_8);
+        }
+
+        // ... getResponse, streamResponse, askQuestion...
+
+        @Override
+        public Stream<String> askQuestionWithContext(String conversationId, String question) {
+            // 1. Crear un mapa con los valores para el template
+            Map<String, Object> model = Map.of(
+                    "context", this.glossaryContext,
+                    "question", question
+            );
+
+            // 2. Crear un Prompt usando el template y el modelo
+            Prompt prompt = this.ragPromptTemplate.create(model);
+
+            // 3. Llamar al LLM con el prompt que ya incluye el contexto
+            return chatClient.prompt(prompt)
+                    .chatReference(conversationId)
+                    .chatMemory(this.chatMemory)
+                    .stream()
+                    .content()
+                    .toStream();
+        }
+    }
+    
+```
+
+Nota: El constructor ahora lanza una IOException. No te olvides de añadir throws IOException a la firma del constructor.
+
+
+### Parte 4 - Exponer un Nuevo Endpoint para RAG
+
+Finalmente, vamos a crear un nuevo endpoint en nuestro `ChatController `para poder probar esta funcionalidad.
+
+Añade el siguiente método a `ChatController.java`
+
+```java
+// src/main/java/com/theitdojo/optimizing_llm_responses_with_rag_in_java/controllers/ChatController.java
+import jakarta.servlet.http.HttpSession;
+// ...
+
+@RestController
+@RequestMapping("/ai")
+public class ChatController {
+    // ... código existente del controlador ...
+    private static final Logger logger = LoggerFactory.getLogger(ChatController.class);
+
+    @GetMapping("/rag")
+    public String rag(HttpSession session, @RequestParam String question) {
+        Stream<String> responseStream = chatAssistant.askQuestionWithContext(session.getId(), question);
+
+        StringBuilder responseBuilder = new StringBuilder();
+
+        responseStream.forEach(chunk -> {
+            logger.info(chunk);
+            responseBuilder.append(chunk);
+        });
+
+        return responseBuilder.toString();
+    }
+}
+```
+
+## Hora de probar nuestro RAG manual 
+
+1. Ejecuta la aplicación.
+2. Abre tu navegador y haz una pregunta cuya respuesta se encuentre en glosario.txt: `http://localhost:8080/ai/rag?question=¿Qué es un emisor?`
+   - Deberías obtener una respuesta precisa basada en la definición del archivo.
+3. Ahora, haz una pregunta que no tenga que ver con el contexto proporcionado: `http://localhost:8080/ai/rag?question=¿Cuál es la capital de España?`
+   - Gracias a nuestras instrucciones en el PromptTemplate, el asistente debería responder algo como: "Lo siento, no tengo la información para responder esa pregunta."
+
+
+### Análisis: Las (Grandes) Limitaciones de este Enfoque 
+
+1. Uso Ineficiente de Tokens y Alto Costo: Con cada pregunta que hacemos al endpoint `/rag`, estamos enviando el contenido completo del archivo `glosario.txt` al LLM. Nuestro glosario tiene ~4KB, lo que equivale a aproximadamente 1000 tokens. Si usáramos una API de pago como la de OpenAI, estaríamos pagando por esos 1000 tokens de contexto en cada consulta, incluso si la pregunta solo necesita una frase del documento para ser respondida. Esto es extremadamente caro e ineficiente.
+2. Límite de la ventana de Contexto: Los LLMs tienen una "ventana de contexto" (context window) finita, es decir, un número máximo de tokens que pueden procesar a la vez (por ejemplo, 4K, 8K, 128K). Nuestro glosario cabe sin problemas, pero ¿qué pasaría si quisiéramos que el asistente respondiera preguntas sobre un manual de 200 páginas o la documentación completa de un proyecto? El texto simplemente no cabría en el prompt, y este enfoque fallaría por completo.
+3. Baja Relevancia y Posible "Ruido": Al enviar todo el documento, le estamos dando al modelo mucha información irrelevante o "ruido". Para responder "¿Qué es un emisor?", no necesita saber la definición de "Manipulación de mercado". Este exceso de información no solo es ineficiente, sino que a veces puede confundir al modelo y degradar la calidad de la respuesta.
+
+
+## Conclusión 
+
+En este ejercicio, hemos implementado una forma rudimentaria de RAG y, lo más importante, hemos aprendido por qué necesitamos una estrategia más inteligente. Hemos demostrado que podemos enseñar a nuestro asistente sobre datos privados, pero también hemos expuesto las debilidades de un enfoque ingenuo.
+
+### Conceptos de LLM que hemos aplicado
+
+- RAG Manual (Context Stuffing): Hemos aplicado el principio básico de RAG: recuperar datos (en este caso, todo el archivo) y aumentarlos en el prompt. Esto prueba que la técnica funciona conceptualmente.
+- Importancia de la Relevancia del Contexto: La principal lección de este ejercicio es una de eficiencia. Descubrimos que enviar contexto irrelevante no solo es costoso en términos de tokens y dinero, sino que también puede "contaminar" el prompt y no es escalable debido a los límites de la ventana de contexto de los LLMs.
+- Control del Comportamiento (Guardrails): A través de nuestro PromptTemplate, instruimos al modelo sobre cómo actuar cuando la respuesta no se encuentra en el contexto. Esta es una práctica fundamental para construir sistemas de RAG confiables y evitar que el modelo "alucine" o invente respuestas.
+
+### Cómo nos ayudó Spring AI
+
+- `PromptTemplate` para Prompts Dinámicos: Esta característica de Spring AI ha sido la estrella del ejercicio. Nos permitió externalizar y estructurar nuestro prompt de RAG de una manera limpia, separando la lógica de la plantilla. Rellenar los marcadores `{context}` y `{question}` dinámicamente es trivial y hace que el código sea mucho más legible y mantenible.
+- API `ChatClient` Consistente: La API fluida del ChatClient nos permitió usar nuestro `Prompt` recién creado con el template relleno de una manera muy natural, demostrando su flexibilidad para manejar tanto prompts simples de usuario como prompts complejos y estructurados.
+
+El problema de la ineficiencia y la escalabilidad nos lleva directamente a la necesidad de una solución más sofisticada. ¿Cómo podemos encontrar y enviar solo los fragmentos de texto más relevantes para la pregunta del usuario, en lugar de todo el documento? La respuesta es utilizando Embeddings y una Base de Datos de Vectores (Vector Store).
+
+### Próximo ejercicio


### PR DESCRIPTION
feat(exercise-4) Manual RAG with Prompt Templates

- Introduces the concept of Retrieval-Augmented Generation (RAG) using a basic, manual approach.
- Demonstrates how to load an entire document (`glosario.txt`) and inject it directly as context into the prompt.
- Utilizes Spring AI's PromptTemplate to structure the RAG prompt, add instructions, and control the model's behavior.
- Focuses on the significant limitations of this "context stuffing" method, including high token usage, cost inefficiency, and context window constraints.
- Sets the stage for the next exercise by clearly explaining why a more advanced solution with vector stores is necessary.

feat(exercise-2): Implement persistent conversational memory and session state.

This commit introduces stateful, persistent conversations by addressing two key areas: user session management and AI chat history. By persisting both using JDBC, the application now correctly remembers users and their conversation context across server restarts, providing a seamless and robust user experience.

The implementation also modernizes the Spring AI integration to use the recommended Advisor pattern for managing chat memory, ensuring the code follows current best practices.